### PR TITLE
Add user profile page with tabbed account UI

### DIFF
--- a/assets/customer.css
+++ b/assets/customer.css
@@ -652,6 +652,129 @@
   font-size: 1.3rem;
 }
 
+/* Account Header */
+.account__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  margin-bottom: 3rem;
+}
+
+.account__logout-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.4rem;
+  color: rgb(var(--color-foreground));
+  text-decoration: none;
+}
+
+.account__logout-link:hover {
+  text-decoration: underline;
+}
+
+.account__logout-link .svg-wrapper {
+  width: 1.5rem;
+}
+
+/* Account Tabs */
+.account__tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  margin-bottom: 3.2rem;
+}
+
+.account__tab {
+  background: none;
+  border: none;
+  border-bottom: 0.2rem solid transparent;
+  padding: 1.2rem 2rem;
+  font-size: 1.4rem;
+  font-family: inherit;
+  color: rgba(var(--color-foreground), 0.6);
+  cursor: pointer;
+  margin-bottom: -0.1rem;
+  transition: color 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.account__tab:hover {
+  color: rgb(var(--color-foreground));
+}
+
+.account__tab--active {
+  color: rgb(var(--color-foreground));
+  border-bottom-color: rgb(var(--color-foreground));
+  font-weight: 600;
+}
+
+.account__tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--color-foreground), 0.08);
+  border-radius: 10rem;
+  font-size: 1.1rem;
+  min-width: 1.8rem;
+  height: 1.8rem;
+  padding: 0 0.5rem;
+  font-weight: 500;
+}
+
+/* Account Panels */
+.account__panel {
+  display: none;
+}
+
+.account__panel--active {
+  display: block;
+}
+
+/* Profile Form */
+.account__profile-fields {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
+@media screen and (min-width: 750px) {
+  .account__profile-fields {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 2rem;
+  }
+}
+
+.account__profile-fields .field {
+  margin-top: 2rem;
+}
+
+.account__profile-fields .field:first-of-type {
+  margin-top: 0;
+}
+
+@media screen and (min-width: 750px) {
+  .account__profile-fields .field:nth-of-type(2) {
+    margin-top: 0;
+  }
+}
+
+.account__password-reset {
+  margin-top: 3.2rem;
+  padding-top: 2.4rem;
+  border-top: 0.1rem solid rgba(var(--color-foreground), 0.08);
+}
+
+.account__password-reset p {
+  margin-bottom: 0.8rem;
+  color: rgba(var(--color-foreground), 0.65);
+  font-size: 1.4rem;
+}
+
 /* Addresses */
 .addresses li > button {
   margin-left: 0.5rem;

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -409,7 +409,15 @@
       "title": "Account",
       "details": "Account details",
       "view_addresses": "View addresses",
-      "return": "Return to Account details"
+      "return": "Return to Account details",
+      "tab_profile": "Profile",
+      "tab_orders": "Orders",
+      "tab_addresses": "Addresses",
+      "profile_heading": "Personal information",
+      "profile_saved": "Profile updated successfully.",
+      "phone": "Phone number",
+      "save_profile": "Save changes",
+      "password_reset_hint": "Want to change your password?"
     },
     "account_fallback": "Account",
     "activate_account": {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -263,7 +263,6 @@
       <!--Ido - Remove search from header  -->
       <!-- {% render 'header-search', input_id: 'Search-In-Modal' %} -->
 
-      <!-- Roman: Remove account from header 
       {%- if shop.customer_accounts_enabled -%}
         <a
           href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}"
@@ -292,7 +291,6 @@
           </span>
         </a>
       {%- endif -%}
-    -->
 
       {%- for block in section.blocks -%}
         {%- case block.type -%}

--- a/sections/main-account.liquid
+++ b/sections/main-account.liquid
@@ -15,9 +15,9 @@
 {%- endstyle -%}
 
 <div class="customer account section-{{ section.id }}-padding">
-  <div>
+  <div class="account__header">
     <h1 class="customer__title">{{ 'customer.account.title' | t }}</h1>
-    <a href="{{ routes.account_logout_url }}">
+    <a href="{{ routes.account_logout_url }}" class="account__logout-link">
       <span class="svg-wrapper">
         {{- 'icon-account.svg' | inline_asset_content -}}
       </span>
@@ -25,70 +25,179 @@
     </a>
   </div>
 
-  <div>
-    <div>
-      <h2>{{ 'customer.orders.title' | t }}</h2>
+  <div class="account__tabs" role="tablist" aria-label="{{ 'customer.account.title' | t }}">
+    <button
+      class="account__tab account__tab--active"
+      role="tab"
+      aria-selected="true"
+      aria-controls="panel-profile"
+      id="tab-profile"
+    >
+      {{ 'customer.account.tab_profile' | t }}
+    </button>
+    <button
+      class="account__tab"
+      role="tab"
+      aria-selected="false"
+      aria-controls="panel-orders"
+      id="tab-orders"
+      tabindex="-1"
+    >
+      {{ 'customer.account.tab_orders' | t }}
+    </button>
+    <button
+      class="account__tab"
+      role="tab"
+      aria-selected="false"
+      aria-controls="panel-addresses"
+      id="tab-addresses"
+      tabindex="-1"
+    >
+      {{ 'customer.account.tab_addresses' | t }}
+      {%- if customer.addresses_count > 0 -%}
+        <span class="account__tab-badge">{{ customer.addresses_count }}</span>
+      {%- endif -%}
+    </button>
+  </div>
 
-      {% paginate customer.orders by 20 %}
-        {%- if customer.orders.size > 0 -%}
-          <table role="table" class="order-history">
-            <caption class="visually-hidden">
-              {{ 'customer.orders.title' | t }}
-            </caption>
-            <thead role="rowgroup">
+  <!-- Profile Info Panel -->
+  <div id="panel-profile" role="tabpanel" aria-labelledby="tab-profile" class="account__panel account__panel--active">
+    <h2>{{ 'customer.account.profile_heading' | t }}</h2>
+    {%- form 'customer', novalidate: 'novalidate' -%}
+      {%- if form.errors -%}
+        <h3 class="form__message" tabindex="-1" autofocus>
+          <span class="svg-wrapper">
+            {{- 'icon-error.svg' | inline_asset_content -}}
+          </span>
+          {{ 'templates.contact.form.error_heading' | t }}
+        </h3>
+        {{ form.errors | default_errors }}
+      {%- endif -%}
+
+      {%- if form.posted_successfully? -%}
+        <h3 class="form__message" tabindex="-1" autofocus>
+          <span class="svg-wrapper">
+            {{- 'icon-success.svg' | inline_asset_content -}}
+          </span>
+          {{ 'customer.account.profile_saved' | t }}
+        </h3>
+      {%- endif -%}
+
+      <div class="account__profile-fields">
+        <div class="field">
+          <input
+            type="text"
+            name="customer[first_name]"
+            id="ProfileFirstName"
+            value="{{ customer.first_name }}"
+            autocomplete="given-name"
+            placeholder="{{ 'customer.register.first_name' | t }}"
+          >
+          <label for="ProfileFirstName">{{ 'customer.register.first_name' | t }}</label>
+        </div>
+
+        <div class="field">
+          <input
+            type="text"
+            name="customer[last_name]"
+            id="ProfileLastName"
+            value="{{ customer.last_name }}"
+            autocomplete="family-name"
+            placeholder="{{ 'customer.register.last_name' | t }}"
+          >
+          <label for="ProfileLastName">{{ 'customer.register.last_name' | t }}</label>
+        </div>
+
+        <div class="field">
+          <input
+            type="email"
+            name="customer[email]"
+            id="ProfileEmail"
+            value="{{ customer.email }}"
+            autocomplete="email"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            {% if form.errors contains 'email' %}
+              aria-invalid="true"
+              aria-describedby="ProfileEmail-error"
+            {% endif %}
+            placeholder="{{ 'customer.login_page.email' | t }}"
+          >
+          <label for="ProfileEmail">{{ 'customer.login_page.email' | t }}</label>
+          {%- if form.errors contains 'email' -%}
+            <small id="ProfileEmail-error" class="form__message">
+              <span class="svg-wrapper">{{- 'icon-error.svg' | inline_asset_content -}}</span>
+              {{ form.errors.translated_fields.email | capitalize }} {{ form.errors.messages.email }}.
+            </small>
+          {%- endif -%}
+        </div>
+
+        <div class="field">
+          <input
+            type="tel"
+            name="customer[phone]"
+            id="ProfilePhone"
+            value="{{ customer.phone }}"
+            autocomplete="tel"
+            placeholder="{{ 'customer.account.phone' | t }}"
+          >
+          <label for="ProfilePhone">{{ 'customer.account.phone' | t }}</label>
+        </div>
+      </div>
+
+      <button type="submit" class="button button--full-width">
+        {{ 'customer.account.save_profile' | t }}
+      </button>
+    {%- endform -%}
+
+    <div class="account__password-reset">
+      <p>{{ 'customer.account.password_reset_hint' | t }}</p>
+      <a href="#recover" class="link">{{ 'customer.login_page.forgot_password' | t }}</a>
+    </div>
+  </div>
+
+  <!-- Orders Panel -->
+  <div id="panel-orders" role="tabpanel" aria-labelledby="tab-orders" class="account__panel" hidden>
+    <h2>{{ 'customer.orders.title' | t }}</h2>
+
+    {% paginate customer.orders by 20 %}
+      {%- if customer.orders.size > 0 -%}
+        <table role="table" class="order-history">
+          <caption class="visually-hidden">{{ 'customer.orders.title' | t }}</caption>
+          <thead role="rowgroup">
+            <tr role="row">
+              <th id="ColumnOrder" scope="col" role="columnheader">{{ 'customer.orders.order_number' | t }}</th>
+              <th id="ColumnDate" scope="col" role="columnheader">{{ 'customer.orders.date' | t }}</th>
+              <th id="ColumnPayment" scope="col" role="columnheader">{{ 'customer.orders.payment_status' | t }}</th>
+              <th id="ColumnFulfillment" scope="col" role="columnheader">{{ 'customer.orders.fulfillment_status' | t }}</th>
+              <th id="ColumnTotal" scope="col" role="columnheader">{{ 'customer.orders.total' | t }}</th>
+            </tr>
+          </thead>
+          <tbody role="rowgroup">
+            {%- for order in customer.orders -%}
               <tr role="row">
-                <th id="ColumnOrder" scope="col" role="columnheader">{{ 'customer.orders.order_number' | t }}</th>
-                <th id="ColumnDate" scope="col" role="columnheader">{{ 'customer.orders.date' | t }}</th>
-                <th id="ColumnPayment" scope="col" role="columnheader">{{ 'customer.orders.payment_status' | t }}</th>
-                <th id="ColumnFulfillment" scope="col" role="columnheader">
-                  {{ 'customer.orders.fulfillment_status' | t }}
-                </th>
-                <th id="ColumnTotal" scope="col" role="columnheader">{{ 'customer.orders.total' | t }}</th>
+                <td id="RowOrder" role="cell" headers="ColumnOrder" data-label="{{ 'customer.orders.order_number' | t }}">
+                  <a href="{{ order.customer_url }}" aria-label="{{ 'customer.orders.order_number_link' | t: number: order.name }}">
+                    {{ order.name }}
+                  </a>
+                </td>
+                <td headers="RowOrder ColumnDate" role="cell" data-label="{{ 'customer.orders.date' | t }}">
+                  {{ order.created_at | time_tag: format: 'date' }}
+                </td>
+                <td headers="RowOrder ColumnPayment" role="cell" data-label="{{ 'customer.orders.payment_status' | t }}">
+                  {{ order.financial_status_label }}
+                </td>
+                <td headers="RowOrder ColumnFulfillment" role="cell" data-label="{{ 'customer.orders.fulfillment_status' | t }}">
+                  {{ order.fulfillment_status_label }}
+                </td>
+                <td headers="RowOrder ColumnTotal" role="cell" data-label="{{ 'customer.orders.total' | t }}">
+                  {{ order.total_net_amount | money_with_currency }}
+                </td>
               </tr>
-            </thead>
-            <tbody role="rowgroup">
-              {%- for order in customer.orders -%}
-                <tr role="row">
-                  <td
-                    id="RowOrder"
-                    role="cell"
-                    headers="ColumnOrder"
-                    data-label="{{ 'customer.orders.order_number' | t }}"
-                  >
-                    <a
-                      href="{{ order.customer_url }}"
-                      aria-label="{{ 'customer.orders.order_number_link' | t: number: order.name }}"
-                    >
-                      {{ order.name }}
-                    </a>
-                  </td>
-                  <td headers="RowOrder ColumnDate" role="cell" data-label="{{ 'customer.orders.date' | t }}">
-                    {{ order.created_at | time_tag: format: 'date' }}
-                  </td>
-                  <td
-                    headers="RowOrder ColumnPayment"
-                    role="cell"
-                    data-label="{{ 'customer.orders.payment_status' | t }}"
-                  >
-                    {{ order.financial_status_label }}
-                  </td>
-                  <td
-                    headers="RowOrder ColumnFulfillment"
-                    role="cell"
-                    data-label="{{ 'customer.orders.fulfillment_status' | t }}"
-                  >
-                    {{ order.fulfillment_status_label }}
-                  </td>
-                  <td headers="RowOrder ColumnTotal" role="cell" data-label="{{ 'customer.orders.total' | t }}">
-                    {{ order.total_net_amount | money_with_currency }}
-                  </td>
-                </tr>
-              {%- endfor -%}
-            </tbody>
-          </table>
-        {%- else -%}
-          <p>{{ 'customer.orders.none' | t }}</p>
-        {%- endif -%}
+            {%- endfor -%}
+          </tbody>
+        </table>
 
         {%- if paginate.pages > 1 -%}
           {%- if paginate.parts.size > 0 -%}
@@ -97,37 +206,27 @@
                 {%- if paginate.previous -%}
                   <li>
                     <a href="{{ paginate.previous.url }}" aria-label="{{ 'general.pagination.previous' | t }}">
-                      <span class="svg-wrapper">
-                        {{- 'icon-caret.svg' | inline_asset_content -}}
-                      </span>
+                      <span class="svg-wrapper">{{- 'icon-caret.svg' | inline_asset_content -}}</span>
                     </a>
                   </li>
                 {%- endif -%}
-
                 {%- for part in paginate.parts -%}
                   <li>
                     {%- if part.is_link -%}
-                      <a href="{{ part.url }}" aria-label="{{ 'general.pagination.page' | t: number: part.title }}">
-                        {{- part.title -}}
-                      </a>
+                      <a href="{{ part.url }}" aria-label="{{ 'general.pagination.page' | t: number: part.title }}">{{ part.title }}</a>
                     {%- else -%}
                       {%- if part.title == paginate.current_page -%}
-                        <span aria-current="page" aria-label="{{ 'general.pagination.page' | t: number: part.title }}">
-                          {{- part.title -}}
-                        </span>
+                        <span aria-current="page" aria-label="{{ 'general.pagination.page' | t: number: part.title }}">{{ part.title }}</span>
                       {%- else -%}
                         <span>{{ part.title }}</span>
                       {%- endif -%}
                     {%- endif -%}
                   </li>
                 {%- endfor -%}
-
                 {%- if paginate.next -%}
                   <li>
                     <a href="{{ paginate.next.url }}" aria-label="{{ 'general.pagination.next' | t }}">
-                      <span class="svg-wrapper">
-                        {{- 'icon-caret.svg' | inline_asset_content -}}
-                      </span>
+                      <span class="svg-wrapper">{{- 'icon-caret.svg' | inline_asset_content -}}</span>
                     </a>
                   </li>
                 {%- endif -%}
@@ -135,20 +234,71 @@
             </nav>
           {%- endif -%}
         {%- endif -%}
-      {% endpaginate %}
-    </div>
+      {%- else -%}
+        <p>{{ 'customer.orders.none' | t }}</p>
+      {%- endif -%}
+    {% endpaginate %}
+  </div>
 
-    <div>
-      <h2>{{ 'customer.account.details' | t }}</h2>
+  <!-- Addresses Panel -->
+  <div id="panel-addresses" role="tabpanel" aria-labelledby="tab-addresses" class="account__panel" hidden>
+    <h2>{{ 'customer.account.details' | t }}</h2>
 
-      {{ customer.default_address | format_address }}
+    {{ customer.default_address | format_address }}
 
-      <a href="{{ routes.account_addresses_url }}">
-        {{ 'customer.account.view_addresses' | t }} ({{ customer.addresses_count }})
-      </a>
-    </div>
+    <a href="{{ routes.account_addresses_url }}" class="button button--secondary">
+      {{ 'customer.account.view_addresses' | t }} ({{ customer.addresses_count }})
+    </a>
   </div>
 </div>
+
+<script>
+  (function () {
+    const tabs = document.querySelectorAll('.account__tab');
+    const panels = document.querySelectorAll('.account__panel');
+
+    tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        tabs.forEach(function (t) {
+          t.classList.remove('account__tab--active');
+          t.setAttribute('aria-selected', 'false');
+          t.setAttribute('tabindex', '-1');
+        });
+        panels.forEach(function (p) {
+          p.classList.remove('account__panel--active');
+          p.hidden = true;
+        });
+
+        tab.classList.add('account__tab--active');
+        tab.setAttribute('aria-selected', 'true');
+        tab.removeAttribute('tabindex');
+
+        var panelId = tab.getAttribute('aria-controls');
+        var panel = document.getElementById(panelId);
+        if (panel) {
+          panel.classList.add('account__panel--active');
+          panel.hidden = false;
+        }
+      });
+
+      tab.addEventListener('keydown', function (e) {
+        var idx = Array.from(tabs).indexOf(tab);
+        if (e.key === 'ArrowRight') {
+          tabs[(idx + 1) % tabs.length].focus();
+          tabs[(idx + 1) % tabs.length].click();
+        } else if (e.key === 'ArrowLeft') {
+          tabs[(idx - 1 + tabs.length) % tabs.length].focus();
+          tabs[(idx - 1 + tabs.length) % tabs.length].click();
+        }
+      });
+    });
+
+    {%- if form.posted_successfully? or form.errors -%}
+      var profileTab = document.getElementById('tab-profile');
+      if (profileTab) profileTab.click();
+    {%- endif -%}
+  })();
+</script>
 
 {% schema %}
 {


### PR DESCRIPTION
- Re-enable account icon in desktop header (was commented out)
- Rebuild main-account.liquid with a 3-tab layout: Profile, Orders, Addresses
- Add editable profile form (first name, last name, email, phone) using {% form 'customer' %}
- Add tab navigation with keyboard arrow key support (ARIA-compliant)
- Add profile-specific styles to customer.css (tabs, profile grid, password reset hint)
- Add English translation strings for all new UI text